### PR TITLE
Make compatible with kitspace.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ interface that could later be translated to hardware in the form of a PCB.
 
 [gerbers](hardware/teensy-fx-2020-02-10-fab.zip)
 
+Buy the right parts through the links on the [kitspace page](https://kitspace.org/boards/github.com/mattvenn/teensy-audio-fx).
+
 ## Hardware Resources
 
 Based off the teensy 4 audio board and the [teensy beats shield](https://hackaday.io/project/161127-teensy-beats-shield)

--- a/kitspace.yaml
+++ b/kitspace.yaml
@@ -1,0 +1,4 @@
+bom: hardware/teensy-fx-bom.csv
+eda:
+    type: kicad
+    pcb: hardware/teensy-fx.kicad_pcb


### PR DESCRIPTION
Hey Matt! So this on twitter, looks neat. 

Adding this kitspace.yaml file makes it possible to add a page on [kitspace.org](https://kitspace.org)  like [your ESP8266-breakout](https://kitspace.org/boards/github.com/mattvenn/esp8266-breakout/).

Here is a preview of this one: http://add-teensy-audio-fx.preview.kitspace.org/boards/github.com/kitspace-forks/teensy-audio-fx/. Some things to note:

- If you'de prefer Kitspace not to plot the gerbers from the kicad_pcb for you, you can unzip them into your repo and add a `gerbers: ` field in the yaml to the gerbers folder.
- Using "dnp" in the Farnell column in the BOM causes some warnings when adding to cart but it seems to work out ok. 